### PR TITLE
fix: correct total number of properties based on current zoopla.co.uk HTML

### DIFF
--- a/pyzoopla/base.py
+++ b/pyzoopla/base.py
@@ -70,8 +70,7 @@ class BaseSearch(Base):
     @property
     def total_properties(self):
         """Total number of properties matching search criteria."""
-        results = int(self.soup.find(name='span', attrs={'class': 'listing-results-utils-count'})
-                      .text.split(' of ')[-1].replace(',', '').replace('+', ''))
+        results = int(zoopla.soup.find(name="p", attrs={"data-testid": "total-results"}).text.split()[0].replace(',', '').replace('+', ''))
         return results
 
     @property

--- a/pyzoopla/base.py
+++ b/pyzoopla/base.py
@@ -70,7 +70,7 @@ class BaseSearch(Base):
     @property
     def total_properties(self):
         """Total number of properties matching search criteria."""
-        results = int(zoopla.soup.find(name="p", attrs={"data-testid": "total-results"}).text.split()[0].replace(',', '').replace('+', ''))
+        results = int(self.soup.find(name="p", attrs={"data-testid": "total-results"}).text.split()[0].replace(',', '').replace('+', ''))
         return results
 
     @property


### PR DESCRIPTION
I am guessing that the HTML structure of the Zoopla website has been changed since these functions were written. This is the first of several expected changes that should correct the `total_properties` property.

Example page: https://www.zoopla.co.uk/to-rent/property/london/ returns 10000.